### PR TITLE
md2-switch-in-rdocx

### DIFF
--- a/R/rdocx_document.R
+++ b/R/rdocx_document.R
@@ -226,6 +226,7 @@ get_reference_rdocx <- memoise(get_docx_uncached)
 #' document. `list("Normal" = c("Author", "Date"))` will result in a document where
 #' all paragraphs styled with stylename "Date" and "Author" will be then styled with
 #' stylename "Normal".
+#' @param md2 if TRUE sets number_section to true
 #' @param reference_num if TRUE, text for references to sections will be
 #' the section number (e.g. '3.2'). If FALSE, text for references to sections
 #' will be the text (e.g. 'section title').
@@ -310,6 +311,7 @@ get_reference_rdocx <- memoise(get_docx_uncached)
 #'       ul.style: null
 #'     mapstyles:
 #'       Normal: ['First Paragraph', 'Author', 'Date']
+#'     md2: false
 #'     page_size:
 #'       width: 8.3
 #'       height: 11.7
@@ -375,7 +377,7 @@ get_reference_rdocx <- memoise(get_docx_uncached)
 rdocx_document <- function(base_format = "rmarkdown::word_document",
                            tables = list(), plots = list(), lists = list(),
                            mapstyles = list(), page_size = list(), page_margins = list(),
-                           reference_num = TRUE, ...) {
+                           md2 = FALSE, reference_num = TRUE, ...) {
 
   args <- list(...)
   if(is.null(args$reference_docx)){
@@ -385,7 +387,11 @@ rdocx_document <- function(base_format = "rmarkdown::word_document",
     )
   }
   if(!is.null(args$number_sections) && isTRUE(args$number_sections)){
-    args$number_sections <- FALSE
+    if (isTRUE(md2)) {
+      args$number_sections <- TRUE
+    } else {
+      args$number_sections <- FALSE
+    }
   }
 
   args$reference_docx <- absolute_path(args$reference_docx)


### PR DESCRIPTION
adds the md2-switch in order to allow disabling auf auto-numberung when using bookdown::markdown_document2